### PR TITLE
fixed decoding hex & base64 from two bytes external strings

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -324,7 +324,7 @@ size_t StringBytes::Write(Isolate* isolate,
     }
 
     case BASE64:
-      if (is_extern) {
+      if (is_extern && str->IsExternalOneByte()) {
         nbytes = base64_decode(buf, buflen, data, external_nbytes);
       } else {
         String::Value value(str);
@@ -336,7 +336,7 @@ size_t StringBytes::Write(Isolate* isolate,
       break;
 
     case HEX:
-      if (is_extern) {
+      if (is_extern && str->IsExternalOneByte()) {
         nbytes = hex_decode(buf, buflen, data, external_nbytes);
       } else {
         String::Value value(str);


### PR DESCRIPTION
Strings in DOM may be converted to two bytes representation, which
should be processed as array of `uint16_t` when decoding hex or
base64.

base64 decoding in Node.js can fallback to a slow implementation
to skip invalid characters (i.e. `\0` in this case). This patch
can also keep base64 decoding running under the fast implementation.

fixed nwjs/nw.js#5069