### PR TITLE
[win] removed exported zlib symbols

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -667,7 +667,7 @@
               '-X^_',
               '-X^private_',
               # Base generated DEF on zlib.def
-              '-Bdeps/zlib/win32/zlib.def'
+              #'-Bdeps/zlib/win32/zlib.def'
             ],
           },
           'conditions': [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

zlib symbols was exported in c843e58 with zlib 1.2.8. Node.js in NW
was built with chromium zlib 1.2.5 + google's patches, which didn't
exported those symbols.