### PR TITLE
move conditions using 'component' to 'target_defaults'

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -33,15 +33,6 @@
     
 
     'conditions': [
-      ['OS=="win" and component=="shared_library"', {
-        # See http://msdn.microsoft.com/en-us/library/aa652367.aspx
-        'win_release_RuntimeLibrary%': '2', # 2 = /MD (nondebug DLL)
-        'win_debug_RuntimeLibrary%': '3',   # 3 = /MDd (debug DLL)
-      }, {
-        # See http://msdn.microsoft.com/en-us/library/aa652367.aspx
-        'win_release_RuntimeLibrary%': '0', # 0 = /MT (nondebug static)
-        'win_debug_RuntimeLibrary%': '1',   # 1 = /MTd (debug static)
-      }],
       ['OS == "win"', {
         'os_posix': 0,
         'v8_postmortem_support%': 'false',
@@ -71,6 +62,19 @@
 
   'target_defaults': {
     'default_configuration': 'Release',
+    'variables': {
+      'conditions': [
+        ['OS=="win" and component=="shared_library"', {
+          # See http://msdn.microsoft.com/en-us/library/aa652367.aspx
+          'win_release_RuntimeLibrary%': '2', # 2 = /MD (nondebug DLL)
+          'win_debug_RuntimeLibrary%': '3',   # 3 = /MDd (debug DLL)
+        }, {
+          # See http://msdn.microsoft.com/en-us/library/aa652367.aspx
+          'win_release_RuntimeLibrary%': '0', # 0 = /MT (nondebug static)
+          'win_debug_RuntimeLibrary%': '1',   # 1 = /MTd (debug static)
+        }],
+      ],
+    },
     'configurations': {
       'Debug': {
         'variables': {


### PR DESCRIPTION
'component' was defined within NW.js building procedure. However it
wasn't defined until including 'common.gypi' when building addons.
Conditions within 'variables' cannot use variable within the same
level. Moving conditions to 'target_defaults' will make 'component'
defined before evaluating the conditions, to prevent addon building
failures.

fixed nwjs/nw-gyp#96