### PR TITLE
Update common.gypi to allow for ARM builds

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -122,6 +122,9 @@
       ['OS=="linux" and target_arch=="x64" and <(building_nw)==1', {
         'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_sid_amd64-sysroot',
       }],
+      ['OS=="linux" and target_arch=="arm" and <(building_nw)==1', {
+        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_sid_arm-sysroot',
+      }],
       ['openssl_fips != ""', {
         'openssl_product': '<(STATIC_LIB_PREFIX)crypto<(STATIC_LIB_SUFFIX)',
       }, {

--- a/common.gypi
+++ b/common.gypi
@@ -537,6 +537,10 @@
             'cflags': [ '--sysroot=<(sysroot)', '-nostdinc++', '-isystem<(DEPTH)/buildtools/third_party/libc++/trunk/include', '-isystem<(DEPTH)/buildtools/third_party/libc++abi/trunk/include' ],
             'ldflags': [ '--sysroot=<(sysroot)','<!(<(DEPTH)/content/nw/tools/sysroot_ld_path.sh <(sysroot))', '-nostdlib++' ],
           }],
+          [ 'OS=="linux" and target_arch=="arm"', {
+            'cflags': [ '--target=arm-linux-gnueabihf' ],
+            'ldflags': [ '--target=arm-linux-gnueabihf' ],
+          }],
           [ 'target_arch=="ppc" and OS!="aix"', {
             'cflags': [ '-m32' ],
             'ldflags': [ '-m32' ],


### PR DESCRIPTION
Chromium's build scripts support building for ARM architectures so long as the ARM sysroot image is installed.
This is one of the requirements for fixing https://github.com/nwjs/nw.js/issues/1151