### PR TITLE
Switch to Debian Bullseye

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -126,13 +126,13 @@
         'v8_enable_31bit_smis_on_64bit_arch': 1,
       }],
       ['OS=="linux" and target_arch=="ia32" and <(building_nw)==1', {
-        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_sid_i386-sysroot',
+        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_bullseye_i386-sysroot',
       }],
       ['OS=="linux" and target_arch=="x64" and <(building_nw)==1', {
-        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_sid_amd64-sysroot',
+        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_bullseye_amd64-sysroot',
       }],
       ['OS=="linux" and target_arch=="arm" and <(building_nw)==1', {
-        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_sid_arm-sysroot',
+        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_bullseye_arm-sysroot',
       }],
       ['OS=="mac"', {
         'clang%': 1,


### PR DESCRIPTION
Closes: #16

NW.js v0.73.x (Chromium 110) has updated to [Debian Bullseye sysroot](https://github.com/nwjs/chromium.src/blob/nw72/build/linux/sysroot_scripts/sysroots.json).