### PR TITLE
Build Node native addon using Python 3

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -65,7 +65,7 @@
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,
-    'v8_host_byteorder': '<!(python -c "import sys; print sys.byteorder")',
+    'v8_host_byteorder': '<!(python3 -c "import sys; print(sys.byteorder)")',
 
     # Sets -dOBJECT_PRINT.
     'v8_enable_object_print%': 1,


### PR DESCRIPTION
Fixes: #46

Currently `nw-builder` is able to build native addons via `node-gyp` _only_ after [patching the Node headers](https://github.com/nwutils/nw-builder/pull/964/commits/88890425966518176da75438c4d19e59a65bfb6f). This patch will have to applied for a range of versions which I still have to figure out. It would be great if this can be upstreamed so that the patch would not need to applied after a certain NW.js version - hopefully from v0.82.0 onward.