### PR TITLE
Move `v8_host_byteorder` from Node to ICU

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -65,7 +65,6 @@
 
     # Enable disassembler for `--print-code` v8 options
     'v8_enable_disassembler': 1,
-    'v8_host_byteorder': '<!(python -c "import sys; print sys.byteorder")',
 
     # Sets -dOBJECT_PRINT.
     'v8_enable_object_print%': 1,


### PR DESCRIPTION
Description

Fixes: #46 

Follow up of https://github.com/nwjs/node/commit/05596971c2aac8479cb6358c6c510ebf8039aadc which turned out to be an incorrect fix. Description of changes is in https://github.com/nwjs/nw.js/pull/8145.