### PR TITLE
[gyp] Update sysroot from `sid` to `bullseye`

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -125,13 +125,13 @@
         'v8_enable_31bit_smis_on_64bit_arch': 1,
       }],
       ['OS=="linux" and target_arch=="ia32" and <(building_nw)==1', {
-        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_sid_i386-sysroot',
+        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_bullseye_i386-sysroot',
       }],
       ['OS=="linux" and target_arch=="x64" and <(building_nw)==1', {
-        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_sid_amd64-sysroot',
+        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_bullseye_amd64-sysroot',
       }],
       ['OS=="linux" and target_arch=="arm" and <(building_nw)==1', {
-        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_sid_arm-sysroot',
+        'sysroot': '<!(cd <(DEPTH) && pwd -P)/build/linux/debian_bullseye_arm64-sysroot',
       }],
       ['OS=="mac"', {
         'clang%': 1,


### PR DESCRIPTION
### Description of Changes

- Chromium has updated their default sysroot from `sid` to `bullseye`.

Refs: [CL:3561495](https://chromium-review.googlesource.com/c/chromium/src/+/3561495)
Closes: #16
Fixes: https://github.com/nwjs/nw.js/issues/8049